### PR TITLE
v0.1.0: add rmAll for maps, fix collection upsert

### DIFF
--- a/lib/collection_methods/get_in_range.js
+++ b/lib/collection_methods/get_in_range.js
@@ -6,7 +6,7 @@ const verifyCriteria = require('../util/verify_criteria')
 module.exports = async (db, { path }, criteria, {
   key,
   start,
-  end,
+  end
 }, { orderBy, orderDirection } = {}) => {
   ensureCollection(db, path)
 

--- a/lib/collection_methods/index.js
+++ b/lib/collection_methods/index.js
@@ -19,5 +19,5 @@ module.exports = {
   bulkInsert,
   insertSorted,
   getInRange,
-  upsert,
+  upsert
 }

--- a/lib/collection_methods/upsert.js
+++ b/lib/collection_methods/upsert.js
@@ -9,7 +9,7 @@ module.exports = async (db, { path, index, indexMatches}, doc) => {
 
   ensureCollection(db, path)
 
-  const collection = db.get(path).values()
+  const collection = db.get(path).values().value()
   const existingIndex = collection.findIndex((d) => {
     for (let i = 0; i < indexMatches.length; i += 1) {
       if (d[indexMatches[i]] !== doc[indexMatches[i]]) {

--- a/lib/collection_methods/upsert.js
+++ b/lib/collection_methods/upsert.js
@@ -2,7 +2,7 @@
 
 const ensureCollection = require('../util/ensure_collection')
 
-module.exports = async (db, { path, index, indexMatches}, doc) => {
+module.exports = async (db, { path, index, indexMatches }, doc) => {
   if (!index) {
     throw new Error('can\'t upsert, model missing index')
   }

--- a/lib/map_methods/index.js
+++ b/lib/map_methods/index.js
@@ -6,6 +6,7 @@ const getAll = require('./get_all')
 const find = require('./find')
 const get = require('./get')
 const set = require('./set')
+const rmAll = require('./rm_all')
 const rm = require('./rm')
 
 module.exports = {
@@ -15,5 +16,6 @@ module.exports = {
   find,
   get,
   set,
+  rmAll,
   rm
 }

--- a/lib/map_methods/rm_all.js
+++ b/lib/map_methods/rm_all.js
@@ -1,0 +1,8 @@
+'use strict'
+
+const ensureMap = require('../util/ensure_map')
+
+module.exports = async (db, { mapKey, path }) => {
+  ensureMap(db, path)
+  db.unset(path).write()
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-hf-models-adapter-lowdb",
-  "version": "0.0.3",
+  "version": "0.1.0",
   "description": "LowDB adapter for the HF database",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
* Adds `rmAll` to map models
* Fixes return value in lowdb query within collection `upsert` method
* Bumps to `0.1.0`