### PR TITLE
Feature: Collection Bulk Upsert 1.0.2

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+# 1.0.2
+- feature: add bulkUpsert() function for collections
+
 # 1.0.1
 - docs: create/update
 

--- a/lib/collection_methods/bulk_upsert.js
+++ b/lib/collection_methods/bulk_upsert.js
@@ -1,0 +1,48 @@
+'use strict'
+
+const ensureCollection = require('../util/ensure_collection')
+
+// NOTE: unique to lowdb
+module.exports = async (db, { path, index, indexMatches }, docs) => {
+  if (!index) {
+    throw new Error('can\'t upsert, model missing index')
+  }
+
+  ensureCollection(db, path)
+
+  const collection = db.get(path).values().value()
+  const toBeInserted = {}
+
+  for (let i = 0; i < docs.length; i += 1) {
+    const doc = docs[i]
+    const key = indexMatches.map(k => doc[k]).join('-')
+    toBeInserted[key] = doc
+  }
+
+  // Check what can be upserted
+  for (let i = 0; i < collection.length; i += 1) {
+    for (let j = 0; j < docs.length; j += 1) {
+      const doc = docs[j]
+      const equal = !indexMatches.find(k => doc[k] !== collection[i][k])
+
+      if (equal) {
+        const key = indexMatches.map(k => doc[k]).join('-')
+
+        collection[i] = doc
+        delete toBeInserted[key]
+        break
+      }
+    }
+  }
+
+  // Insert the rest
+  const insert = Object.values(toBeInserted)
+
+  for (let i = 0; i < insert.length; i += 1) {
+    collection.push(insert[i])
+  }
+
+  db.set(path, collection).write()
+
+  return docs
+}

--- a/lib/collection_methods/index.js
+++ b/lib/collection_methods/index.js
@@ -9,6 +9,7 @@ const bulkInsert = require('./bulk_insert')
 const insertSorted = require('./insert_sorted')
 const getInRange = require('./get_in_range')
 const upsert = require('./upsert')
+const bulkUpsert = require('./bulk_upsert')
 
 module.exports = {
   find,
@@ -19,5 +20,6 @@ module.exports = {
   bulkInsert,
   insertSorted,
   getInRange,
-  upsert
+  upsert,
+  bulkUpsert
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-hf-models-adapter-lowdb",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "LowDB adapter for the HF database",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
### Description:
Adds a `bulkUpsert()` method for collections. This is not supported by knex.js for PSQL so it is unique to this adapter. Consumers need to check if the method is available on their `bfx-hf-models` instance.

### New features:
- [x] `bulkUpsert()`

### PR status:
- [x] Version bumped
- [x] Change-log updated
- [ ] Tests added or updated
- [ ] Documentation updated
